### PR TITLE
バリデーションエラー修正と期限切れタスクの完了ボタン追加

### DIFF
--- a/next_one/app/views/tasks/index.html.erb
+++ b/next_one/app/views/tasks/index.html.erb
@@ -41,6 +41,9 @@
         （締切: <%= task.due_on %> / 期限切れ）
         <br>
         <%= task.memo %>
+        <br>
+
+        <%= button_to "完了", toggle_status_task_path(task), method: :patch %>
       </li>
     <% end %>
   </ul>

--- a/next_one/config/locales/ja.yml
+++ b/next_one/config/locales/ja.yml
@@ -15,6 +15,10 @@ ja:
     messages:
       blank: を入力してください
       taken: はすでに使用されています
+      too_short: は%{count}文字以上で入力してください
+      too_long: は%{count}文字以内で入力してください
+      invalid: は不正な値です
+      confirmation: が一致しません
       not_saved:
         one: "1件のエラーが発生したため保存できませんでした"
         other: "%{count}件のエラーが発生したため保存できませんでした"


### PR DESCRIPTION
## 変更内容
- Devise / ActiveRecord のバリデーションメッセージの日本語化を追加
- 新規登録時のパスワード文字数エラーなどで Translation missing が出ないよう修正
- 期限切れタスク欄にも完了ボタンを追加
- 期限切れタスクを完了済みに移動できるよう修正
